### PR TITLE
Add the ability to pass options along with Icing commands

### DIFF
--- a/commands/prepare.js
+++ b/commands/prepare.js
@@ -88,7 +88,10 @@ module.exports = {
       // Ask away!
       let ingredients = await inquirer.prompt(recipe.ingredients);
       let consolatedIngredients = Object.assign(
-        { ...projectIngredients, ...ingredients },
+        {
+          ...projectIngredients,
+          ...ingredients
+        },
         {
           projectNameDocker: projectIngredients.projectName.replace(/-/g, '_')
         }
@@ -125,7 +128,8 @@ module.exports = {
           ui.log.write(`  . ${icing.description}`);
           if (Array.isArray(icing.cmd)) {
             await executeCommand(
-              addIngredients(icing.cmd, consolatedIngredients)
+              addIngredients(icing.cmd, consolatedIngredients),
+              icing.cmdOptions
             );
           }
         }

--- a/docs/pages/docs/ezbake-a-project/index.md
+++ b/docs/pages/docs/ezbake-a-project/index.md
@@ -43,11 +43,13 @@ You may also execute local commands relative to the root of the project being cl
 
 Also, icing commands can be enhanced with `ingredients`. Simply reference the `ingredient.name` using the same template syntax you used for scaffolding your project. (e.g. `<%= someIngredientName >`)
 
-## Example 
+Every icing command is executed in a child process. If you need to do something fancy like changing to a different directory before executing that command, you can pass in a `cmdOptions: {...}` parameter with your icing. The options accepted are the options from the [Node spawn command](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
+
+## Example
 
 ```js
 module.exports = {
-  source: { 
+  source: {
     "**/*.txt": true,
     "**/*.sql": true,
     "**/*.yml": true,
@@ -81,6 +83,11 @@ module.exports = {
     {
       description: 'Says something on Mac',
       cmd: ['./icing.sh']
+    },
+    {
+      description: 'Change to a subdirectory and execute an npm install',
+      cmd: ['npm', 'install'],
+      cmdOptions: {cwd: '../scripts'}
     },
     {
       description: 'Tells me the job is done',

--- a/tasks/filesystem.js
+++ b/tasks/filesystem.js
@@ -12,11 +12,11 @@ module.exports = {
   executeCommand
 };
 
-function executeCommand(command) {
+function executeCommand(command, cmdOptions) {
   return new Promise((resolve, reject) => {
     let cmd = command[0];
     let args = command.length > 1 ? command.slice(1) : [];
-    let execCmd = spawn(cmd, args);
+    let execCmd = spawn(cmd, args, cmdOptions);
     execCmd.stdout.on('data', data => {
       console.log(`  ${data}`);
     });
@@ -44,7 +44,9 @@ function createEnvFile(ui, projectName, answers) {
       return previous.concat(current);
     }, '');
 
-  fs.writeFileSync(pathToEnvFile, contents, { encoding: 'utf8' });
+  fs.writeFileSync(pathToEnvFile, contents, {
+    encoding: 'utf8'
+  });
   ui.log.write(`. Wrote ${pathToEnvFile} successfully`);
 }
 
@@ -55,7 +57,10 @@ function walkSync(dir, filelist) {
     if (fs.statSync(path.join(dir, file)).isDirectory()) {
       filelist = walkSync(path.join(dir, file), filelist);
     } else {
-      filelist.push({ path: path.join(dir, file), name: file });
+      filelist.push({
+        path: path.join(dir, file),
+        name: file
+      });
     }
   });
   return filelist;


### PR DESCRIPTION
For AppirioDX we needed to be able to change to a different directory before running an icing command. We enabled that by passing an option to the spawned child process like this https://stackoverflow.com/questions/20156067/node-js-child-process-spawnnpm-install-in-grunt-task-results-in-enoent-err

For this purpose we needed to add this extra option to the icing command.