### PR TITLE
Fix a bug where paths with spaces cause an error; split git commands into 4 separate commands to be performed at different times

### DIFF
--- a/commands/prepare.js
+++ b/commands/prepare.js
@@ -13,7 +13,9 @@ const {
   cloneRepo,
   deleteGitFolder,
   establishLocalGitBindings,
-  pushLocalGitToOrigin
+  addGitRemote,
+  pushLocalGitToOrigin,
+  stageChanges
 } = require('../tasks/git');
 
 const {
@@ -93,9 +95,14 @@ module.exports = {
           ...ingredients
         },
         {
-        projectNameDocker: projectIngredients.projectName.replace(/-/g, '_'),
-        projectAuthor: projectIngredients.authorName + " <" + projectIngredients.authorEmail + ">"
-      });
+          projectNameDocker: projectIngredients.projectName.replace(/-/g, '_'),
+          projectAuthor:
+            projectIngredients.authorName +
+            ' <' +
+            projectIngredients.authorEmail +
+            '>'
+        }
+      );
 
       bakeProject(ui, consolatedIngredients, recipe);
 
@@ -106,10 +113,10 @@ module.exports = {
       }
 
       // Finally, establish a local .git binding
-      // And optionally push to a specified remote repo
+      // And optionally add the specified remote
       await establishLocalGitBindings(ui, projectIngredients.projectName);
       if (projectIngredients.gitOriginURL) {
-        await pushLocalGitToOrigin(
+        await addGitRemote(
           ui,
           projectIngredients.gitOriginURL,
           projectIngredients.projectName
@@ -134,6 +141,21 @@ module.exports = {
           }
         }
         ui.log.write(`. Icing applied!`);
+      }
+
+      // Finally, stage and commit the changes.
+      // And optionally push to a remote repo
+      await stageChanges(
+        ui,
+        '[ezbake] - initial commit',
+        projectIngredients.projectName
+      );
+      if (projectIngredients.gitOriginURL) {
+        await pushLocalGitToOrigin(
+          ui,
+          projectIngredients.gitOriginURL,
+          projectIngredients.projectName
+        );
       }
 
       ui.log.write(`. Your project is ready!`);

--- a/tasks/git.js
+++ b/tasks/git.js
@@ -81,7 +81,7 @@ function establishLocalGitBindings(ui, projectName) {
     const pathToProject = path.join(cwd, `./${projectName}`);
     ui.log.write(`. Establishing new local .git bindings...\n`);
     exec(
-      `cd ${pathToProject} && git init && git add . && git commit -m "[ezbake] - get it while it's hot!"`,
+      `cd "${pathToProject}" && git init && git add . && git commit -m "[ezbake] - get it while it's hot!"`,
       (err, stdout, stderr) => {
         if (err || stderr) {
           return reject(

--- a/tasks/git.js
+++ b/tasks/git.js
@@ -1,7 +1,10 @@
 const path = require('path');
 const cwd = path.resolve(process.cwd());
 const rimraf = require('rimraf');
-const { spawn, exec } = require('child_process');
+const {
+  spawn,
+  exec
+} = require('child_process');
 
 module.exports = {
   cloneRepo,
@@ -81,7 +84,7 @@ function establishLocalGitBindings(ui, projectName) {
     const pathToProject = path.join(cwd, `./${projectName}`);
     ui.log.write(`. Establishing new local .git bindings...\n`);
     exec(
-      `cd "${pathToProject}" && git init && git add . && git commit -m "[ezbake] - get it while it's hot!"`,
+      `cd "${pathToProject}" && git init && git add . && git commit -m "[ezbake] - initial commit"`,
       (err, stdout, stderr) => {
         if (err || stderr) {
           return reject(
@@ -105,7 +108,7 @@ function pushLocalGitToOrigin(ui, gitOriginURL, projectName) {
     const pathToProject = path.join(cwd, `./${projectName}`);
     ui.log.write(`. Pushing to ${gitOriginURL}\n`);
     exec(
-      `cd ${pathToProject} && git remote add origin ${gitOriginURL} && git push -u origin master`,
+      `cd "${pathToProject}" && git remote add origin ${gitOriginURL} && git push -u origin master`,
       (err, stdout, stderr) => {
         ui.log.write(`  . ${stdout}\n`);
         if (err) {

--- a/tasks/git.js
+++ b/tasks/git.js
@@ -1,26 +1,26 @@
 const path = require('path');
 const cwd = path.resolve(process.cwd());
 const rimraf = require('rimraf');
-const {
-  spawn,
-  exec
-} = require('child_process');
+const { spawn, exec } = require('child_process');
 
 module.exports = {
   cloneRepo,
   deleteGitFolder,
   establishLocalGitBindings,
+  addGitRemote,
   pushLocalGitToOrigin,
   stageChanges
 };
 
-function stageChanges(ui, commitMessage) {
+function stageChanges(ui, commitMessage, projectName = '.') {
   return new Promise((resolve, reject) => {
+    pathToProject =
+      projectName === '.' ? cwd : path.join(cwd, `./${projectName}`);
     ui.log.write(
       `. Staging git changes with commit message "${commitMessage}". \n`
     );
     exec(
-      `git add . && git commit -m "${commitMessage}"`,
+      `cd "${pathToProject}" && git add . && git commit -m "${commitMessage}"`,
       (err, stdout, stderr) => {
         if (err || stderr) {
           return reject(
@@ -83,19 +83,39 @@ function establishLocalGitBindings(ui, projectName) {
   return new Promise((resolve, reject) => {
     const pathToProject = path.join(cwd, `./${projectName}`);
     ui.log.write(`. Establishing new local .git bindings...\n`);
+    exec(`cd "${pathToProject}" && git init`, (err, stdout, stderr) => {
+      if (err || stderr) {
+        return reject(
+          new Error(
+            `! Could not establish a local git binding in ${pathToProject}. Please check your permissions or if git exists on your PATH.`
+          )
+        );
+      }
+      ui.log.write(
+        `. Finished establishing new local .git binding in ${pathToProject}.\n`
+      );
+      return resolve();
+    });
+  });
+}
+
+function addGitRemote(ui, gitOriginURL, projectName) {
+  // Assumption: process is already changed to the project directory
+  return new Promise((resolve, reject) => {
+    const pathToProject = path.join(cwd, `./${projectName}`);
+    ui.log.write(`. Adding a git remote ${gitOriginURL}\n`);
     exec(
-      `cd "${pathToProject}" && git init && git add . && git commit -m "[ezbake] - initial commit"`,
+      `cd "${pathToProject}" && git remote add origin ${gitOriginURL}`,
       (err, stdout, stderr) => {
-        if (err || stderr) {
+        ui.log.write(`  . ${stdout}\n`);
+        if (err) {
           return reject(
             new Error(
-              `! Could not establish a local git binding in ${pathToProject}. Please check your permissions or if git exists on your PATH.`
+              `! Could not add the remote ${gitOriginURL} to ${pathToProject}. Please check the URL.`
             )
           );
         }
-        ui.log.write(
-          `. Finished establishing new local .git binding in ${pathToProject}.\n`
-        );
+        ui.log.write(`. Succesfully added git remote: ${gitOriginURL}.\n`);
         return resolve();
       }
     );
@@ -108,7 +128,7 @@ function pushLocalGitToOrigin(ui, gitOriginURL, projectName) {
     const pathToProject = path.join(cwd, `./${projectName}`);
     ui.log.write(`. Pushing to ${gitOriginURL}\n`);
     exec(
-      `cd "${pathToProject}" && git remote add origin ${gitOriginURL} && git push -u origin master`,
+      `cd "${pathToProject}" && git push -u origin master`,
       (err, stdout, stderr) => {
         ui.log.write(`  . ${stdout}\n`);
         if (err) {


### PR DESCRIPTION
We're not handling spaces if a user has /spaces in/their/project path/