### PR TITLE
Fix ezbake crash on Windows when deleting a directory.

### DIFF
--- a/tasks/filesystem.js
+++ b/tasks/filesystem.js
@@ -1,10 +1,7 @@
 const inquirer = require('inquirer');
 const fs = require('fs-extra');
 const path = require('path');
-const {
-  spawn,
-  exec
-} = require('child_process');
+const { spawn, exec } = require('child_process');
 const cwd = path.resolve(process.cwd());
 const shellescape = require('shell-escape');
 
@@ -75,19 +72,21 @@ async function checkForExistingFolder(ui, projectName) {
     let directoryExists = fs.existsSync(directory);
     if (directoryExists) {
       inquirer
-        .prompt([{
-          type: 'input',
-          name: 'projectName',
-          message: `${directory} already exists. Please specify a new name. If you keep the current name, it will be deleted.`,
-          default: `${projectName}`,
-          filter: val => {
-            return val
-              .replace(/\W+/g, ' ') // alphanumerics only
-              .trimRight()
-              .replace(/ /g, '-')
-              .toLowerCase();
+        .prompt([
+          {
+            type: 'input',
+            name: 'projectName',
+            message: `${directory} already exists. Please specify a new name. If you keep the current name, it will be deleted.`,
+            default: `${projectName}`,
+            filter: val => {
+              return val
+                .replace(/\W+/g, ' ') // alphanumerics only
+                .trimRight()
+                .replace(/ /g, '-')
+                .toLowerCase();
+            }
           }
-        }])
+        ])
         .then(directoryAnswers => {
           if (directoryAnswers.projectName === projectName) {
             fs
@@ -98,7 +97,9 @@ async function checkForExistingFolder(ui, projectName) {
               })
               .catch(err => {
                 return reject(
-                  `We've had problems removing the ${directory}. Do you have enough permissions to delete it?`
+                  new Error(
+                    `We've had problems removing the ${directory}. Do you have enough permissions to delete it?`
+                  )
                 );
               });
           } else {

--- a/tasks/filesystem.js
+++ b/tasks/filesystem.js
@@ -1,7 +1,10 @@
 const inquirer = require('inquirer');
 const fs = require('fs-extra');
 const path = require('path');
-const { spawn, exec } = require('child_process');
+const {
+  spawn,
+  exec
+} = require('child_process');
 const cwd = path.resolve(process.cwd());
 const shellescape = require('shell-escape');
 
@@ -72,33 +75,32 @@ async function checkForExistingFolder(ui, projectName) {
     let directoryExists = fs.existsSync(directory);
     if (directoryExists) {
       inquirer
-        .prompt([
-          {
-            type: 'input',
-            name: 'projectName',
-            message: `${directory} already exists. Please specify a new name. If you keep the current name, it will be deleted.`,
-            default: `${projectName}`,
-            filter: val => {
-              return val
-                .replace(/\W+/g, ' ') // alphanumerics only
-                .trimRight()
-                .replace(/ /g, '-')
-                .toLowerCase();
-            }
+        .prompt([{
+          type: 'input',
+          name: 'projectName',
+          message: `${directory} already exists. Please specify a new name. If you keep the current name, it will be deleted.`,
+          default: `${projectName}`,
+          filter: val => {
+            return val
+              .replace(/\W+/g, ' ') // alphanumerics only
+              .trimRight()
+              .replace(/ /g, '-')
+              .toLowerCase();
           }
-        ])
+        }])
         .then(directoryAnswers => {
           if (directoryAnswers.projectName === projectName) {
-            const rm = spawn('rm', [`-rf`, directory]);
-            rm.on('close', code => {
-              if (code !== 0) {
+            fs
+              .remove(directory)
+              .then(() => {
+                ui.log.write(`! Deleted ${directory}`);
+                return resolve(projectName);
+              })
+              .catch(err => {
                 return reject(
                   `We've had problems removing the ${directory}. Do you have enough permissions to delete it?`
                 );
-              }
-              ui.log.write(`! Deleted ${directory}`);
-              return resolve(projectName);
-            });
+              });
           } else {
             return resolve(directoryAnswers.projectName);
           }

--- a/tasks/filesystem.js
+++ b/tasks/filesystem.js
@@ -98,7 +98,7 @@ async function checkForExistingFolder(ui, projectName) {
               .catch(err => {
                 return reject(
                   new Error(
-                    `We've had problems removing the ${directory}. Do you have enough permissions to delete it?`
+                    `We've had problems removing the ${directory}. Do you have enough permissions to delete it? Make sure that the directory isn't open in any program/terminal.`
                   )
                 );
               });


### PR DESCRIPTION
This PR references Issue: #30 and fixes it so that deletion of directories becomes OS independent.
Current implementation uses **spawn** with **rm** and **rf** which are not recognized on Windows. 
Thus using **remove** function from the **fs-extra** module to make it work for all operating systems.