### PR TITLE
Added '--follow-tags' with git push

### DIFF
--- a/tasks/filesystem.js
+++ b/tasks/filesystem.js
@@ -1,10 +1,7 @@
 const inquirer = require('inquirer');
 const fs = require('fs-extra');
 const path = require('path');
-const {
-  spawn,
-  exec
-} = require('child_process');
+const { spawn, exec } = require('child_process');
 const cwd = path.resolve(process.cwd());
 const shellescape = require('shell-escape');
 
@@ -75,19 +72,21 @@ async function checkForExistingFolder(ui, projectName) {
     let directoryExists = fs.existsSync(directory);
     if (directoryExists) {
       inquirer
-        .prompt([{
-          type: 'input',
-          name: 'projectName',
-          message: `${directory} already exists. Please specify a new name. If you keep the current name, it will be deleted.`,
-          default: `${projectName}`,
-          filter: val => {
-            return val
-              .replace(/\W+/g, ' ') // alphanumerics only
-              .trimRight()
-              .replace(/ /g, '-')
-              .toLowerCase();
+        .prompt([
+          {
+            type: 'input',
+            name: 'projectName',
+            message: `${directory} already exists. Please specify a new name. If you keep the current name, it will be deleted.`,
+            default: `${projectName}`,
+            filter: val => {
+              return val
+                .replace(/\W+/g, ' ') // alphanumerics only
+                .trimRight()
+                .replace(/ /g, '-')
+                .toLowerCase();
+            }
           }
-        }])
+        ])
         .then(directoryAnswers => {
           if (directoryAnswers.projectName === projectName) {
             fs
@@ -98,7 +97,9 @@ async function checkForExistingFolder(ui, projectName) {
               })
               .catch(err => {
                 return reject(
-                  `We've had problems removing the ${directory}. Do you have enough permissions to delete it?`
+                  new Error(
+                    `We've had problems removing the ${directory}. Do you have enough permissions to delete it?`
+                  )
                 );
               });
           } else {

--- a/tasks/filesystem.js
+++ b/tasks/filesystem.js
@@ -1,7 +1,10 @@
 const inquirer = require('inquirer');
 const fs = require('fs-extra');
 const path = require('path');
-const { spawn, exec } = require('child_process');
+const {
+  spawn,
+  exec
+} = require('child_process');
 const cwd = path.resolve(process.cwd());
 const shellescape = require('shell-escape');
 
@@ -72,33 +75,32 @@ async function checkForExistingFolder(ui, projectName) {
     let directoryExists = fs.existsSync(directory);
     if (directoryExists) {
       inquirer
-        .prompt([
-          {
-            type: 'input',
-            name: 'projectName',
-            message: `${directory} already exists. Please specify a new name. If you keep the current name, it will be deleted.`,
-            default: `${projectName}`,
-            filter: val => {
-              return val
-                .replace(/\W+/g, ' ') // alphanumerics only
-                .trimRight()
-                .replace(/ /g, '-')
-                .toLowerCase();
-            }
+        .prompt([{
+          type: 'input',
+          name: 'projectName',
+          message: `${directory} already exists. Please specify a new name. If you keep the current name, it will be deleted.`,
+          default: `${projectName}`,
+          filter: val => {
+            return val
+              .replace(/\W+/g, ' ') // alphanumerics only
+              .trimRight()
+              .replace(/ /g, '-')
+              .toLowerCase();
           }
-        ])
+        }])
         .then(directoryAnswers => {
           if (directoryAnswers.projectName === projectName) {
-            const rm = spawn('rm', [`-rf`, directory]);
-            rm.on('close', code => {
-              if (code !== 0) {
+            fs
+              .remove(directory)
+              .then(() => {
+                ui.log.write(`! Deleted ${directory}`);
+                return resolve(projectName);
+              })
+              .catch(err => {
                 return reject(
                   `We've had problems removing the ${directory}. Do you have enough permissions to delete it?`
                 );
-              }
-              ui.log.write(`! Deleted ${directory}`);
-              return resolve(projectName);
-            });
+              });
           } else {
             return resolve(directoryAnswers.projectName);
           }

--- a/tasks/filesystem.js
+++ b/tasks/filesystem.js
@@ -98,7 +98,7 @@ async function checkForExistingFolder(ui, projectName) {
               .catch(err => {
                 return reject(
                   new Error(
-                    `We've had problems removing the ${directory}. Do you have enough permissions to delete it?`
+                    `We've had problems removing the ${directory}. Do you have enough permissions to delete it? Make sure that the directory isn't open in any program/terminal.`
                   )
                 );
               });

--- a/tasks/git.js
+++ b/tasks/git.js
@@ -128,7 +128,7 @@ function pushLocalGitToOrigin(ui, gitOriginURL, projectName) {
     const pathToProject = path.join(cwd, `./${projectName}`);
     ui.log.write(`. Pushing to ${gitOriginURL}\n`);
     exec(
-      `cd "${pathToProject}" && git push -u origin master`,
+      `cd "${pathToProject}" && git push -u origin master --follow-tags`,
       (err, stdout, stderr) => {
         ui.log.write(`  . ${stdout}\n`);
         if (err) {


### PR DESCRIPTION
Hey!
It'd be good to have --follow-tags with the git push command when we finally push the commit to the remote repository. Since icing commands might have created some tags internally and this flag will allow to send these tags over to the remote with the git push.
Currently, git push only pushes the branch head and not the tags.

Read documentation on this flag [here](https://git-scm.com/docs/git-push/2.2.0#git-push---follow-tags)

> --follow-tags
    Push all the refs that would be pushed without this option, and also push annotated tags in refs/tags that are missing from the remote but are pointing at commit-ish that are reachable from the refs being pushed.
